### PR TITLE
Added a test for parsing prefix expressions…

### DIFF
--- a/lib/parser/parser_test.go
+++ b/lib/parser/parser_test.go
@@ -8,6 +8,7 @@ By following "Writing an Interpreter in Go" by Thorsten Ball, https://interprete
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/tmoore2016/interpreter/lib/ast"
@@ -210,5 +211,79 @@ func TestIntegerLiteralExpression(t *testing.T) {
 	// Fail if the token for integer literal "5" isn't "5"
 	if literal.TokenLiteral() != "5" {
 		t.Errorf("literal.TokenLiteral not %s. got=%s", "5", literal.TokenLiteral())
+	}
+}
+
+// testIntegerLiteral is a smaller integer literal test than testIntegerLiteralExpression
+func testIntegerLiteral(t *testing.T, il ast.Expression, value int64) bool {
+	integ, ok := il(*ast.IntegerLiteral)
+
+	// if type isn't integerLiteral, fail
+	if !ok {
+		t.Errorf("il not *ast.IntegerLiteral. got=%T", il)
+		return false
+	}
+
+	// if value != input value, fail
+	if integ.Value != value {
+		t.Errorf("integ.Value not %d. got=%d", value, integ.Value)
+		return false
+	}
+
+	// If token literal doesn't include a type and a value, fail.
+	if integ.TokenLiteral() != fmt.Sprintf("%d", value) {
+		t.Errorf("integ.TokenLiteral not %d. got=%s", value, integ.TokenLiteral())
+		return false
+	}
+
+	return true
+}
+
+// TestParsingPrefixExpressions will test prefix expressions ! and -
+func TestParsingPrefixExpressions(t *testing.T) {
+
+	// Declare input types, prevents having to rewrite the same test for new input.
+	prefixTests := []struct {
+		input        string
+		operator     string
+		integerValue int64
+	}{
+		// Each set of input
+		{"!8;", "!", 8},
+		{"-16;", "-", 16},
+	}
+
+	// for the range of input, call a new lexer, parse the information, and run a parser check.
+	for _, tt := range prefixTests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		program := p.ParseProgram()
+		checkParserErrors(t, p)
+
+		// If there is no input, fail.
+		if len(program.Statements) != 1 {
+			t.Fatalf("program.Statements does not contain %d statements. got=%d\n", l, len(program.Statements))
+		}
+
+		// If program statement 0 is not an AST expression statement, fail
+		stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+		if !ok {
+			t.Fatalf("program.Statements[0] is not ast.ExpressionStatement. got=%T", program.Statements[0])
+		}
+
+		// If program statement isn't an ast prefix expression, fail
+		exp, ok := stmt.Expression.(*ast.PrefixExpression)
+		if !ok {
+			t.Fatalf("stmt is not ast.PrefixExpression. got=%T", stmt.Expression)
+		}
+
+		// If expression operator isn't expected token type, fail
+		if exp.Operator != tt.operator {
+			t.Fatalf("exp.Operator is not '%s'. got=%s", tt.operator, exp.Operator)
+		}
+
+		if !testIntegerLiteral(t, exp.Right, tt.integerValue) {
+			return
+		}
 	}
 }


### PR DESCRIPTION
Added a test for parsing prefix expressions, and a second, smaller test for integerLiterals. These tests will fail because the expression doesn't currently exist in the AST or parser.