### PR TITLE
Added Boolean parsing with tests, converts string type to Bool type.

### DIFF
--- a/lib/parser/parser_test.go
+++ b/lib/parser/parser_test.go
@@ -418,6 +418,22 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 			"3 + 4 * 5 == 3 * 1 + 4 * 5",
 			"((3 + (4 * 5)) == ((3 * 1) + (4 * 5)))",
 		},
+		{
+			"true",
+			"true",
+		},
+		{
+			"false",
+			"false",
+		},
+		{
+			"9 > 99 == false",
+			"((9 > 99) == false)",
+		},
+		{
+			"9 < 99 == true",
+			"((9 < 99) == true)",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Diverged from the book here. The book uses an inline call to set the Boolean to "TRUE" with no explanation other than "its interesting". I think this is wrong(?) I followed the method for converting integer literals instead and it appears to be working. There are more Boolean tests to write before I'll know for sure. I wrote and commented out the book's Boolean method just in case.